### PR TITLE
Add pytest setup and test for Vision average_bbox

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+opencv-python

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,0 +1,10 @@
+from vision import Vision
+
+def test_average_bbox():
+    vision = Vision()
+    vision.bbox_history.extend([
+        (0, 0, 10, 10),
+        (2, 2, 12, 12),
+        (4, 4, 14, 14),
+    ])
+    assert vision.average_bbox() == (2, 2, 12, 12)


### PR DESCRIPTION
## Summary
- set up `pytest` in `requirements.txt`
- add simple unit test for `Vision.average_bbox`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6850084f8d38832db2df67bef59bd847