### PR TITLE
Add unit tests for vision and conversation modules

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,44 @@
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def setup_fake_modules(monkeypatch):
+    fake_pyttsx3 = ModuleType("pyttsx3")
+    fake_pyttsx3.init = MagicMock(return_value=MagicMock())
+
+    fake_sr = ModuleType("speech_recognition")
+    fake_sr.Recognizer = MagicMock()
+    fake_sr.Microphone = MagicMock()
+
+    fake_gc_mod = ModuleType("groq_client")
+    class DummyGroqClient:
+        def get_text_response(self, system_message, user_message):
+            return "dummy"
+    fake_gc_mod.GroqClient = DummyGroqClient
+
+    monkeypatch.setitem(sys.modules, "pyttsx3", fake_pyttsx3)
+    monkeypatch.setitem(sys.modules, "speech_recognition", fake_sr)
+    monkeypatch.setitem(sys.modules, "groq_client", fake_gc_mod)
+
+
+def test_respond_invokes_groq_and_speak(monkeypatch):
+    setup_fake_modules(monkeypatch)
+
+    import conversation
+    importlib.reload(conversation)
+
+    conv = conversation.Conversation()
+    conv.groq_client = MagicMock()
+    conv.groq_client.get_text_response.return_value = "hello"
+    conv.speak = MagicMock()
+
+    conv.respond("hi")
+
+    conv.groq_client.get_text_response.assert_called_with(
+        "You are a conversational droid.", "hi"
+    )
+    conv.speak.assert_called_with("hello")

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -5,18 +5,18 @@ from vision import Vision
 
 
 def test_average_bbox():
-    v = Vision.__new__(Vision)
+    v = Vision()
     v.bbox_history = deque([(0, 0, 10, 10), (2, 2, 10, 10), (4, 4, 10, 10)], maxlen=5)
     assert v.average_bbox() == (2, 2, 10, 10)
 
 
 def test_scale_bbox():
-    v = Vision.__new__(Vision)
+    v = Vision()
     assert v._scale_bbox((10, 20, 15, 25)) == (20, 40, 30, 50)
 
 
 def test_determine_position():
-    v = Vision.__new__(Vision)
+    v = Vision()
     frame = np.zeros((100, 300, 3), dtype=np.uint8)
     assert v._determine_position(frame, (10, 0, 10, 10)) == "LEFT"
     assert v._determine_position(frame, (110, 0, 10, 10)) == "CENTER"

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,0 +1,23 @@
+import numpy as np
+from collections import deque
+
+from vision import Vision
+
+
+def test_average_bbox():
+    v = Vision.__new__(Vision)
+    v.bbox_history = deque([(0, 0, 10, 10), (2, 2, 10, 10), (4, 4, 10, 10)], maxlen=5)
+    assert v.average_bbox() == (2, 2, 10, 10)
+
+
+def test_scale_bbox():
+    v = Vision.__new__(Vision)
+    assert v._scale_bbox((10, 20, 15, 25)) == (20, 40, 30, 50)
+
+
+def test_determine_position():
+    v = Vision.__new__(Vision)
+    frame = np.zeros((100, 300, 3), dtype=np.uint8)
+    assert v._determine_position(frame, (10, 0, 10, 10)) == "LEFT"
+    assert v._determine_position(frame, (110, 0, 10, 10)) == "CENTER"
+    assert v._determine_position(frame, (210, 0, 10, 10)) == "RIGHT"


### PR DESCRIPTION
## Summary
- add pytest configuration
- test average_bbox, _scale_bbox and _determine_position in Vision
- mock Groq client and pyttsx3 in Conversation tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685020755da0832dbfb51e3e59f3ddae