### PR TITLE
Add stop event for clean shutdown

### DIFF
--- a/conversation.py
+++ b/conversation.py
@@ -12,17 +12,26 @@ logger = logging.getLogger(__name__)
 class Conversation:
     """Handle voice input and output for chatting with the user."""
 
-    def __init__(self):
-        """Initialize the text-to-speech engine, recognizer and Groq client."""
+    def __init__(self, stop_event=None):
+        """Initialize the text-to-speech engine, recognizer and Groq client.
+
+        Parameters
+        ----------
+        stop_event : threading.Event, optional
+            Event used to signal when the listening loop should terminate.
+        """
         self.engine = pyttsx3.init()
         self.recognizer = speech_recognition.Recognizer()
         self.groq_client = GroqClient()
+        # Shared stop event allows external callers to shut down the loop
+        self.stop_event = stop_event
 
     def listen(self):
         """Continuously listen to the microphone and respond."""
         logger.info("Started listening...")
 
-        while True:
+        # Run until an external shutdown signal is received
+        while self.stop_event is None or not self.stop_event.is_set():
             with speech_recognition.Microphone() as source:
                 self.recognizer.adjust_for_ambient_noise(source, duration=0.5)
                 audio = self.recognizer.listen(source)
@@ -43,6 +52,8 @@ class Conversation:
                         "Could not request results from Google Speech Recognition service; %s",
                         e,
                     )
+
+        logger.info("Stopped listening")
 
 
     def respond(self, text):

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """Entry point for running the droid's conversation and vision threads."""
 
 import logging
-from threading import Thread
+from threading import Thread, Event
 from conversation import Conversation
 from vision import Vision
 
@@ -14,8 +14,10 @@ class Droid:
     def __init__(self):
         """Create subsystem instances and storage for threads."""
         self.threads = []
-        self.conversation = Conversation()
-        self.vision = Vision()
+        # Shared event that signals all threads to shut down gracefully
+        self.stop_event = Event()
+        self.conversation = Conversation(stop_event=self.stop_event)
+        self.vision = Vision(stop_event=self.stop_event)
 
     def start(self):
         """Launch conversation and vision threads."""
@@ -31,8 +33,16 @@ class Droid:
         for thread in self.threads:
             thread.start()
 
-        for thread in self.threads:
-            thread.join()
+        try:
+            for thread in self.threads:
+                thread.join()
+        except KeyboardInterrupt:
+            logger.info("Shutdown requested by user")
+            self.stop_event.set()
+            for thread in self.threads:
+                thread.join()
+        finally:
+            logger.info("Droid stopped")
 
 if __name__ == '__main__':
     Droid().start()

--- a/vision.py
+++ b/vision.py
@@ -10,11 +10,19 @@ logger = logging.getLogger(__name__)
 class Vision:
     """Detects faces in a video stream and tracks their position."""
 
-    def __init__(self, cam_index=0, frame_width=320, frame_height=240):
-        """Initialize camera settings and tracking state."""
+    def __init__(self, cam_index=0, frame_width=320, frame_height=240, stop_event=None):
+        """Initialize camera settings and tracking state.
+
+        Parameters
+        ----------
+        stop_event : threading.Event, optional
+            Event used to signal when the vision loop should terminate.
+        """
         self.cam_index = cam_index
         self.frame_width = frame_width
         self.frame_height = frame_height
+        # Event used to stop the capture loop gracefully
+        self.stop_event = stop_event
 
         self.face_cascade = cv2.CascadeClassifier(cv2.data.haarcascades + 'haarcascade_frontalface_default.xml')
         self.cap = cv2.VideoCapture(self.cam_index)
@@ -41,7 +49,10 @@ class Vision:
             return
 
         logger.info("Vision system started...")
-        while self.cap.isOpened():
+        while (
+            self.cap.isOpened()
+            and (self.stop_event is None or not self.stop_event.is_set())
+        ):
             ret, frame = self.cap.read()
             if not ret:
                 break
@@ -58,6 +69,7 @@ class Vision:
             cv2.waitKey(1)
 
         self._release_resources()
+        logger.info("Vision system stopped")
 
     # 3. Handle Face Tracking Logic
     def _process_tracking(self, frame, frame_display):


### PR DESCRIPTION
## Summary
- allow Conversation to accept a stop event and check it in `listen`
- add stop event support in Vision and its capture loop
- control lifecycle of both subsystems in `Droid` with shared event and KeyboardInterrupt handling

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685022af1cc4832db64523974cc95a7a