### PR TITLE
Improve error handling for Groq and camera

### DIFF
--- a/groq_client.py
+++ b/groq_client.py
@@ -1,6 +1,7 @@
 """Wrapper around the Groq SDK used to generate chat responses."""
 
 import logging
+import os
 from groq import Groq
 
 logger = logging.getLogger(__name__)
@@ -11,7 +12,12 @@ class GroqClient:
 
     def __init__(self):
         """Instantiate the underlying Groq client."""
-        self.client = Groq()
+        api_key = os.getenv("GROQ_API_KEY")
+        if not api_key:
+            logger.error(
+                "GROQ_API_KEY environment variable is not set. API requests will fail."
+            )
+        self.client = Groq(api_key=api_key) if api_key else Groq()
 
     def get_text_response(self, system_message, user_message):
         """Return Groq's response for a given user message."""

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,6 +1,5 @@
 import numpy as np
 from collections import deque
-from unittest.mock import MagicMock
 
 import cv2
 from vision import Vision

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,21 +1,37 @@
 import numpy as np
 from collections import deque
+from unittest.mock import MagicMock
 
+import cv2
 from vision import Vision
 
 
-def test_average_bbox():
+class DummyCapture:
+    def __init__(self, *args, **kwargs):
+        self.opened = True
+
+    def set(self, *args, **kwargs):
+        pass
+
+    def isOpened(self):
+        return self.opened
+
+
+def test_average_bbox(monkeypatch):
+    monkeypatch.setattr(cv2, "VideoCapture", lambda *a, **k: DummyCapture())
     v = Vision()
     v.bbox_history = deque([(0, 0, 10, 10), (2, 2, 10, 10), (4, 4, 10, 10)], maxlen=5)
     assert v.average_bbox() == (2, 2, 10, 10)
 
 
-def test_scale_bbox():
+def test_scale_bbox(monkeypatch):
+    monkeypatch.setattr(cv2, "VideoCapture", lambda *a, **k: DummyCapture())
     v = Vision()
     assert v._scale_bbox((10, 20, 15, 25)) == (20, 40, 30, 50)
 
 
-def test_determine_position():
+def test_determine_position(monkeypatch):
+    monkeypatch.setattr(cv2, "VideoCapture", lambda *a, **k: DummyCapture())
     v = Vision()
     frame = np.zeros((100, 300, 3), dtype=np.uint8)
     assert v._determine_position(frame, (10, 0, 10, 10)) == "LEFT"

--- a/vision.py
+++ b/vision.py
@@ -20,6 +20,8 @@ class Vision:
         self.cap = cv2.VideoCapture(self.cam_index)
         self.cap.set(cv2.CAP_PROP_FRAME_WIDTH, self.frame_width)
         self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self.frame_height)
+        if not self.cap.isOpened():
+            raise RuntimeError(f"Could not open camera index {self.cam_index}")
 
         self.tracker = None
         self.tracking = False


### PR DESCRIPTION
## Summary
- check GROQ_API_KEY presence and log an error if missing
- raise an exception when the camera can't be opened
- patch tests to fake a camera so they don't require hardware

## Testing
- `PYTHONPATH=$PYTHONPATH:. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685022c00014832d90b436f68e6df706