### PR TITLE
Improve CI caching

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,7 +13,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13.5'
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
+        env:
+          PIP_CACHE_DIR: ~/.cache/pip
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- add pip cache to GitHub Actions workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vision')*

------
https://chatgpt.com/codex/tasks/task_b_68502890cc30832da803cfbb08bf613e