### PR TITLE
Add configurable Groq parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,26 @@ Run the droid with:
 ```bash
 python main.py
 ```
+
+### Customizing prompts and models
+
+`Conversation` allows overriding the system prompt and the Groq model used for
+completions. Defaults match the previous behaviour:
+
+```python
+from conversation import Conversation
+
+# Use a custom prompt and model
+conv = Conversation(
+    system_prompt="You are a helpful robot.",
+    groq_model="llama-3.1-8b-instant",
+)
+```
+
+`GroqClient` can also be instantiated directly with a custom model:
+
+```python
+from groq_client import GroqClient
+
+client = GroqClient(model="llama-3.1-8b-instant")
+```

--- a/conversation.py
+++ b/conversation.py
@@ -12,17 +12,25 @@ logger = logging.getLogger(__name__)
 class Conversation:
     """Handle voice input and output for chatting with the user."""
 
-    def __init__(self, stop_event=None):
+    def __init__(self, stop_event=None, system_prompt="You are a conversational droid.", groq_model="llama-3.1-8b-instant"):
         """Initialize the text-to-speech engine, recognizer and Groq client.
 
         Parameters
         ----------
         stop_event : threading.Event, optional
             Event used to signal when the listening loop should terminate.
+        system_prompt : str, optional
+            Custom system prompt to pass to the model. Defaults to
+            "You are a conversational droid.".
+        groq_model : str, optional
+            Name of the Groq model to use. Defaults to
+            "llama-3.1-8b-instant".
         """
         self.engine = pyttsx3.init()
         self.recognizer = speech_recognition.Recognizer()
-        self.groq_client = GroqClient()
+        self.groq_client = GroqClient(model=groq_model)
+        # Prompt used when requesting completions
+        self.system_prompt = system_prompt
         # Shared stop event allows external callers to shut down the loop
         self.stop_event = stop_event
 
@@ -58,7 +66,7 @@ class Conversation:
 
     def respond(self, text):
         """Get a text response from the Groq model and speak it."""
-        res = self.groq_client.get_text_response("You are a conversational droid.", text)
+        res = self.groq_client.get_text_response(self.system_prompt, text)
 
         logger.info("Droid: %s", res)
 

--- a/groq_client.py
+++ b/groq_client.py
@@ -10,14 +10,22 @@ logger = logging.getLogger(__name__)
 class GroqClient:
     """Simple client used to request completions from Groq."""
 
-    def __init__(self):
-        """Instantiate the underlying Groq client."""
+    def __init__(self, model: str = "llama-3.1-8b-instant"):
+        """Instantiate the underlying Groq client.
+
+        Parameters
+        ----------
+        model : str, optional
+            Name of the Groq model to use for completions. Defaults to
+            "llama-3.1-8b-instant".
+        """
         api_key = os.getenv("GROQ_API_KEY")
         if not api_key:
             logger.error(
                 "GROQ_API_KEY environment variable is not set. API requests will fail."
             )
         self.client = Groq(api_key=api_key) if api_key else Groq()
+        self.model = model
 
     def get_text_response(self, system_message, user_message):
         """Return Groq's response for a given user message."""
@@ -32,7 +40,7 @@ class GroqClient:
                     "content": user_message,
                 }
             ],
-            model="llama-3.1-8b-instant",
+            model=self.model,
         )
 
         return chat_completion.choices[0].message.content

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -16,6 +16,9 @@ def setup_fake_modules(monkeypatch):
 
     fake_gc_mod = ModuleType("groq_client")
     class DummyGroqClient:
+        def __init__(self, model="llama-3.1-8b-instant"):
+            self.model = model
+
         def get_text_response(self, system_message, user_message):
             return "dummy"
     fake_gc_mod.GroqClient = DummyGroqClient
@@ -42,3 +45,35 @@ def test_respond_invokes_groq_and_speak(monkeypatch):
         "You are a conversational droid.", "hi"
     )
     conv.speak.assert_called_with("hello")
+
+
+def test_custom_prompt_and_model(monkeypatch):
+    """Conversation should pass custom prompt and model to GroqClient."""
+    fake_pyttsx3 = ModuleType("pyttsx3")
+    fake_pyttsx3.init = MagicMock(return_value=MagicMock())
+
+    fake_sr = ModuleType("speech_recognition")
+    fake_sr.Recognizer = MagicMock()
+    fake_sr.Microphone = MagicMock()
+
+    fake_gc_mod = ModuleType("groq_client")
+    fake_client_instance = MagicMock()
+    FakeGroqClient = MagicMock(return_value=fake_client_instance)
+    fake_gc_mod.GroqClient = FakeGroqClient
+
+    monkeypatch.setitem(sys.modules, "pyttsx3", fake_pyttsx3)
+    monkeypatch.setitem(sys.modules, "speech_recognition", fake_sr)
+    monkeypatch.setitem(sys.modules, "groq_client", fake_gc_mod)
+
+    import conversation
+    importlib.reload(conversation)
+
+    conv = conversation.Conversation(system_prompt="sys", groq_model="model-x")
+
+    FakeGroqClient.assert_called_with(model="model-x")
+    fake_client_instance.get_text_response.return_value = "ok"
+    conv.speak = MagicMock()
+
+    conv.respond("hi")
+
+    fake_client_instance.get_text_response.assert_called_with("sys", "hi")

--- a/tests/test_groq_client.py
+++ b/tests/test_groq_client.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def test_custom_model(monkeypatch):
+    """GroqClient should use the provided model when requesting completions."""
+    dummy_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))]
+    )
+
+    fake_groq = ModuleType("groq")
+
+    class DummyChat:
+        def __init__(self):
+            self.completions = SimpleNamespace(create=MagicMock(return_value=dummy_response))
+
+    class DummyGroq:
+        def __init__(self, api_key=None):
+            self.chat = DummyChat()
+
+    fake_groq.Groq = DummyGroq
+    monkeypatch.setitem(sys.modules, "groq", fake_groq)
+
+    import groq_client
+    importlib.reload(groq_client)
+
+    client = groq_client.GroqClient(model="test-model")
+    client.get_text_response("sys", "user")
+
+    client.client.chat.completions.create.assert_called_with(
+        messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "user"},
+        ],
+        model="test-model",
+    )


### PR DESCRIPTION
## Summary
- allow customizing Groq model and system prompt
- document the new configuration options
- test that Conversation passes parameters through
- test that GroqClient uses custom model

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685028cf7224832d9ee1046cf1eaab5c